### PR TITLE
Configure master NumPy 1.11 builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,8 @@ os: osx
 env:
   matrix:
     
-    - CONDA_NPY=110  CONDA_PY=27
     - CONDA_NPY=111  CONDA_PY=27
-    - CONDA_NPY=110  CONDA_PY=34
     - CONDA_NPY=111  CONDA_PY=34
-    - CONDA_NPY=110  CONDA_PY=35
     - CONDA_NPY=111  CONDA_PY=35
   global:
     # The BINSTAR_TOKEN secure variable. This is defined canonically in conda-forge.yml.

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -41,14 +41,7 @@ conda clean --lock
 conda install --yes --quiet conda-forge-build-setup
 source run_conda_forge_build_setup
 
-# Embarking on 6 case(s).
-    set -x
-    export CONDA_NPY=110
-    export CONDA_PY=27
-    set +x
-    conda build /recipe_root --quiet || exit 1
-    /feedstock_root/ci_support/upload_or_check_non_existence.py /recipe_root conda-forge --channel=main || exit 1
-
+# Embarking on 3 case(s).
     set -x
     export CONDA_NPY=111
     export CONDA_PY=27
@@ -57,22 +50,8 @@ source run_conda_forge_build_setup
     /feedstock_root/ci_support/upload_or_check_non_existence.py /recipe_root conda-forge --channel=main || exit 1
 
     set -x
-    export CONDA_NPY=110
-    export CONDA_PY=34
-    set +x
-    conda build /recipe_root --quiet || exit 1
-    /feedstock_root/ci_support/upload_or_check_non_existence.py /recipe_root conda-forge --channel=main || exit 1
-
-    set -x
     export CONDA_NPY=111
     export CONDA_PY=34
-    set +x
-    conda build /recipe_root --quiet || exit 1
-    /feedstock_root/ci_support/upload_or_check_non_existence.py /recipe_root conda-forge --channel=main || exit 1
-
-    set -x
-    export CONDA_NPY=110
-    export CONDA_PY=35
     set +x
     conda build /recipe_root --quiet || exit 1
     /feedstock_root/ci_support/upload_or_check_non_existence.py /recipe_root conda-forge --channel=main || exit 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
 build:
   number: 202
   # We lack openblas on Windows, and therefore can't build numpy there either currently.
-  skip: true  # [win]
+  skip: true  # [win or np!=111]
   features:
     - blas_{{ variant }}
 


### PR DESCRIPTION
Configures builds of scikit-learn that link against NumPy 1.11 to occur in this branch only.

cc @amueller