### PR TITLE
Release v0.20.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ package:
 source:
   fn: for0.20.1.tar.gz
   url: https://github.com/jnothman/scikit-learn/archive/for0.20.1.zip
-  sha256: f9c695a2099303c3afe988319bfd196e5459f3054a45b844c4f336286a8ebe19
+  sha256: 00c2778d3e7ff75f55c0b9ee67bac598fb2d84696a265cd7f2861ba813be049d
 
 build:
   number: 1200

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,8 +7,8 @@ package:
   version: {{ version }}
 
 source:
-  fn: 0.20.1.tar.gz
-  url: https://github.com/scikit-learn/scikit-learn/archive/0.20.1.zip
+  fn: {{ version }}.tar.gz
+  url: https://github.com/scikit-learn/scikit-learn/archive/{{ version }}.zip
   sha256: 63c5099bfc7b4d849c36d3434b9b67233a75978c23dc32a9eb46f06704cc9cfe
 
 build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.20.0" %}
+{% set version = "0.20.1" %}
 {% set name = "scikit-learn" %}
 {% set variant = "openblas" %}
 
@@ -7,12 +7,12 @@ package:
   version: {{ version }}
 
 source:
-  fn: {{ version }}.tar.gz
-  url: https://github.com/scikit-learn/scikit-learn/archive/{{ version }}.tar.gz
-  sha256: 6f0e84931af697d7c2841ccdf50110f69cc964788f503e2f43eeaf0240482dc0
+  fn: for0.20.1.tar.gz
+  url: https://github.com/jnothman/scikit-learn/archive/for0.20.1.zip
+  sha256: f9c695a2099303c3afe988319bfd196e5459f3054a45b844c4f336286a8ebe19
 
 build:
-  number: 1201
+  number: 1200
   # We lack scipy on Windows, and therefore can't build numpy there either currently.
   skip: true  # [win]
   features:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ package:
 source:
   fn: {{ version }}.tar.gz
   url: https://github.com/scikit-learn/scikit-learn/archive/{{ version }}.zip
-  sha256: 63c5099bfc7b4d849c36d3434b9b67233a75978c23dc32a9eb46f06704cc9cfe
+  sha256: 5f78b8d2cd13afdfeef297dd1f898a4d45024a35cf4288ef7f4f29b12c75d91f
 
 build:
   number: 1200

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ package:
 source:
   fn: for0.20.1.tar.gz
   url: https://github.com/jnothman/scikit-learn/archive/for0.20.1.zip
-  sha256: 00c2778d3e7ff75f55c0b9ee67bac598fb2d84696a265cd7f2861ba813be049d
+  sha256: 4ce1968d5532d49836f0a3526409741d5e30f64115b1fb3c15ccffee2a476eb7
 
 build:
   number: 1200

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,9 +7,9 @@ package:
   version: {{ version }}
 
 source:
-  fn: for0.20.1.tar.gz
-  url: https://github.com/jnothman/scikit-learn/archive/for0.20.1.zip
-  sha256: 4ce1968d5532d49836f0a3526409741d5e30f64115b1fb3c15ccffee2a476eb7
+  fn: 0.20.1.tar.gz
+  url: https://github.com/scikit-learn/scikit-learn/archive/0.20.1.zip
+  sha256: 63c5099bfc7b4d849c36d3434b9b67233a75978c23dc32a9eb46f06704cc9cfe
 
 build:
   number: 1200

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,8 +8,8 @@ package:
 
 source:
   fn: {{ version }}.tar.gz
-  url: https://github.com/scikit-learn/scikit-learn/archive/{{ version }}.zip
-  sha256: 5f78b8d2cd13afdfeef297dd1f898a4d45024a35cf4288ef7f4f29b12c75d91f
+  url: https://github.com/scikit-learn/scikit-learn/archive/{{ version }}.tar.gz
+  sha256: 618feea121c59a52ea459d6af7bc179344ca345775b04bd60e96740e9df75960
 
 build:
   number: 1200
@@ -46,7 +46,7 @@ test:
   imports:
     - sklearn
   commands:
-    - OPENBLAS_NUM_THREADS=2 pytest --pyargs sklearn
+    - OPENBLAS_NUM_THREADS=1 pytest --pyargs sklearn
 
 about:
   home: http://scikit-learn.org/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -46,7 +46,7 @@ test:
   imports:
     - sklearn
   commands:
-    - pytest --pyargs sklearn
+    - OPENBLAS_NUM_THREADS=2 pytest --pyargs sklearn
 
 about:
   home: http://scikit-learn.org/


### PR DESCRIPTION
Do not merge (yet).

This tests the upcoming 0.20.1 release from https://github.com/scikit-learn/scikit-learn/pull/12383 to make sure that tests pass and in particular that https://github.com/conda-forge/scikit-learn-feedstock/issues/77 was fixed.