### PR TITLE
Trigger macOS / Py37 build for 0.22.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 7132d376a5cb605847022724e9a5dd294bd7c8a988e686b954fdeb00e24fe302
 
 build:
-  number: 0
+  number: 1
   skip: True  # [py2k]
   script:
     - rm $PREFIX/include/cblas.h  # [not win]


### PR DESCRIPTION
The issue with the build for macOS / Py37 should have been fixed by:
https://github.com/conda-forge/python-feedstock/pull/304
