### PR TITLE
[ci skip] Also run migrations on the RC branch

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -2,3 +2,6 @@ build_platform: {osx_arm64: osx_64}
 conda_forge_output_validation: true
 provider: {linux_aarch64: default, linux_ppc64le: default, win: azure}
 test_on_native_only: true
+bot:
+  abi_migration_branches:
+    - "rc"


### PR DESCRIPTION
This tells the fleet of conda-forge bots to also add the migrations to the `rc` branch.