### PR TITLE
MNT Trigger only doctest on ppc64le+pypy build

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
    - patches/0001-ignore-errors-when-tearing-down-modules.patch
 
 build:
-  number: 0
+  number: 1
   skip: true  # [py<37]
   script:
     - rm $PREFIX/include/cblas.h  # [not win]
@@ -71,6 +71,7 @@ requirements:
                                          + " or test_sample_without_replacement_algorithms" %}
 {% endif %}
 {% if ppc64le and python_impl == "pypy" %}
+   # WARNING:
    # On Travis, the pypy build is timing out and we need to skip all tests
    # Then, we only test the docstring
    {% set tests_to_skip = tests_to_skip + " or test" %}


### PR DESCRIPTION
Skipping completely the test for pypy since we cannot even run 20% of the full test suite.