### PR TITLE
Add llvm-openmp to host requirements for osx

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
    - patches/0001-ignore-errors-when-tearing-down-modules.patch
 
 build:
-  number: 2
+  number: 3
   skip: true  # [py<37]
   script:
     - rm $PREFIX/include/cblas.h  # [not win]
@@ -40,6 +40,7 @@ requirements:
     - scipy >=0.17.0
     - joblib >=0.11
     - threadpoolctl
+    - llvm-openmp  # [osx]
   run:
     - python
     - {{ pin_compatible('numpy') }}


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

This PR adds `llvm-openmp` to the host requirements which fixes #176. The run requirements of `osx` builds contain at the moment `llvm-openmp>=11` and `llvm-openmp>=12` (since the release of `llvm-openmp=12`). The former is added by `scikit-learn`'s [build requirement](https://github.com/conda-forge/scikit-learn-feedstock/blob/d674415f4d642978ac16fb5252f564f981b3159c/recipe/meta.yaml#L33). The later by `libopenblas=0.3.18=openmp*` being a depency added to the host environment by [`libcblas`](https://github.com/conda-forge/scikit-learn-feedstock/blob/d674415f4d642978ac16fb5252f564f981b3159c/recipe/meta.yaml#L38) via `libblas`. The host environment is solved having `llvm-openmp=12` since no explicit dependency of `llvm-openmp` is given. Due to the run exports of by `llvm-openmp` versions both are added to the runtime requirements of `scikit-learn`. This PR enforces the `llvm-openmp` version being in sync between host and build environment.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
