### PR TITLE
CI Fixes compiler issue on windows pypy37

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -114,7 +114,7 @@ test:
     # reduce contention for parallelism (xdist-workers, openblas, openmp) that
     # actually increases the runtime and can lead to timeouts
     - export OMP_NUM_THREADS=1                 # [aarch64 or ppc64le]
-    - pytest --pyargs sklearn -k "not ({{ tests_to_skip }})" -nauto --timeout=1200 --durations=50  # [not ppc64le]
+    - pytest --pyargs sklearn -k "not ({{ tests_to_skip }})" -nauto --timeout=1200 --durations=50 -v # [not ppc64le]
     # NOTE: test suite is skipped on ppc due to bugs in QEMU code that cause
     # CI to fail, even though the tests should run through on native hardware
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -51,7 +51,6 @@ requirements:
     - threadpoolctl
 
 {% set tests_to_skip = "_not_a_real_test" %}
-{% set pytest_xdist_n_arg = "-nauto" %}
 {% set extra_pytest_args = "" %}
 # https://github.com/scikit-learn/scikit-learn/issues/20335
 {% set tests_to_skip = tests_to_skip + " or test_loadings_converges" %}
@@ -80,8 +79,6 @@ requirements:
                                          + " or test_spectral_embedding_precomputed_affinity" %}
     # this problem is exacerbated for PyPy; skip some more tests there
     {% if python_impl == "pypy" %}
-        # Do not run in parallel for pypy on windows
-        {% set pytest_xdist_n_arg = "" %}  # [win]
         {% set tests_to_skip = tests_to_skip + " or (test_bagging and (test_regression or test_classification))"
                                              + " or (check_estimator_sparse_data and (Sequential or TSNE or RFECV))"
                                              + " or (test_ensemble_heterogeneous_estimators_behavior and stacking)"
@@ -117,7 +114,7 @@ test:
     # reduce contention for parallelism (xdist-workers, openblas, openmp) that
     # actually increases the runtime and can lead to timeouts
     - export OMP_NUM_THREADS=1                 # [aarch64 or ppc64le]
-    - pytest --pyargs sklearn -k "not ({{ tests_to_skip }})" {{ pytest_xdist_n_arg }} --timeout=1200 --durations=50  # [not ppc64le]
+    - pytest --pyargs sklearn -k "not ({{ tests_to_skip }})" -nauto --timeout=1200 --durations=50  # [not ppc64le]
     # NOTE: test suite is skipped on ppc due to bugs in QEMU code that cause
     # CI to fail, even though the tests should run through on native hardware
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -114,7 +114,7 @@ test:
     # reduce contention for parallelism (xdist-workers, openblas, openmp) that
     # actually increases the runtime and can lead to timeouts
     - export OMP_NUM_THREADS=1                 # [aarch64 or ppc64le]
-    - pytest --pyargs sklearn -k "not ({{ tests_to_skip }})" -nauto --timeout=1200 --durations=50 -v # [not ppc64le]
+    - pytest --pyargs sklearn -k "not ({{ tests_to_skip }})" -nauto --timeout=1200 --durations=50 -v  # [not ppc64le]
     # NOTE: test suite is skipped on ppc due to bugs in QEMU code that cause
     # CI to fail, even though the tests should run through on native hardware
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -51,6 +51,7 @@ requirements:
     - threadpoolctl
 
 {% set tests_to_skip = "_not_a_real_test" %}
+{% set pytest_xdist_n_arg = "-nauto" %}
 {% set extra_pytest_args = "" %}
 # https://github.com/scikit-learn/scikit-learn/issues/20335
 {% set tests_to_skip = tests_to_skip + " or test_loadings_converges" %}
@@ -79,6 +80,8 @@ requirements:
                                          + " or test_spectral_embedding_precomputed_affinity" %}
     # this problem is exacerbated for PyPy; skip some more tests there
     {% if python_impl == "pypy" %}
+        # Do not run in parallel for pypy on windows
+        {% set pytest_xdist_n_arg = "" %}  # [win]
         {% set tests_to_skip = tests_to_skip + " or (test_bagging and (test_regression or test_classification))"
                                              + " or (check_estimator_sparse_data and (Sequential or TSNE or RFECV))"
                                              + " or (test_ensemble_heterogeneous_estimators_behavior and stacking)"
@@ -114,7 +117,7 @@ test:
     # reduce contention for parallelism (xdist-workers, openblas, openmp) that
     # actually increases the runtime and can lead to timeouts
     - export OMP_NUM_THREADS=1                 # [aarch64 or ppc64le]
-    - pytest --pyargs sklearn -k "not ({{ tests_to_skip }})" -nauto --timeout=1200 --durations=50  # [not ppc64le]
+    - pytest --pyargs sklearn -k "not ({{ tests_to_skip }})" {{ pytest_xdist_n_arg }} --timeout=1200 --durations=50  # [not ppc64le]
     # NOTE: test suite is skipped on ppc due to bugs in QEMU code that cause
     # CI to fail, even though the tests should run through on native hardware
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,9 +9,10 @@ source:
   sha256: 34471662f0e5ba8d2c799391338c6f976680cc66b715e00db0c7589f4f371bc4
   patches:
    - patches/0001-ignore-errors-when-tearing-down-modules.patch
+   - patches/0002-MAINT-Use-push_back-directly-in-dbscan_inner.patch
 
 build:
-  number: 0
+  number: 1
   skip: true  # [py<37]
   script:
     - rm $PREFIX/include/cblas.h  # [not win]

--- a/recipe/patches/0002-MAINT-Use-push_back-directly-in-dbscan_inner.patch
+++ b/recipe/patches/0002-MAINT-Use-push_back-directly-in-dbscan_inner.patch
@@ -1,0 +1,38 @@
+From a0f407313563c4db35fbca629d751dcd66ea3e64 Mon Sep 17 00:00:00 2001
+From: "Thomas J. Fan" <thomasjpfan@gmail.com>
+Date: Sun, 26 Dec 2021 08:57:28 -0500
+Subject: [PATCH] MAINT Use push_back directly in dbscan_inner
+
+---
+ sklearn/cluster/_dbscan_inner.pyx | 8 +-------
+ 1 file changed, 1 insertion(+), 7 deletions(-)
+
+diff --git a/sklearn/cluster/_dbscan_inner.pyx b/sklearn/cluster/_dbscan_inner.pyx
+index e293bdd93a..1550c980f5 100644
+--- a/sklearn/cluster/_dbscan_inner.pyx
++++ b/sklearn/cluster/_dbscan_inner.pyx
+@@ -10,12 +10,6 @@ import numpy as np
+ np.import_array()
+ 
+ 
+-# Work around Cython bug: C++ exceptions are not caught unless thrown within
+-# a cdef function with an "except +" declaration.
+-cdef extern inline void push(vector[np.npy_intp] &stack, np.npy_intp i) except +:
+-    stack.push_back(i)
+-
+-
+ def dbscan_inner(np.ndarray[np.uint8_t, ndim=1, mode='c'] is_core,
+                  np.ndarray[object, ndim=1] neighborhoods,
+                  np.ndarray[np.npy_intp, ndim=1, mode='c'] labels):
+@@ -39,7 +33,7 @@ def dbscan_inner(np.ndarray[np.uint8_t, ndim=1, mode='c'] is_core,
+                     for i in range(neighb.shape[0]):
+                         v = neighb[i]
+                         if labels[v] == -1:
+-                            push(stack, v)
++                            stack.push_back(v)
+ 
+             if stack.size() == 0:
+                 break
+-- 
+2.34.1
+


### PR DESCRIPTION
I think this should fix the issue with windows pypy37 with 1.0.2 seen in https://github.com/conda-forge/scikit-learn-feedstock/pull/179/checks

I opened https://github.com/scikit-learn/scikit-learn/pull/22077 to fix the issue on the scikit-learn repo.