### PR TITLE
Build with pinned llvm-openmp

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,6 +40,7 @@ requirements:
     - scipy >=1.8  # [aarch64]
     - joblib >=1.2.0
     - threadpoolctl >=3.1.0
+   # See https://github.com/conda-forge/openmp-feedstock/issues/126
     - llvm-openmp  # [osx]
     - libgomp  # [linux]
   run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: cd2aac2b566c7e740d34aabb4737864c74ba33c29aad7101fbf1bab2931c02dc
 
 build:
-  number: 0
+  number: 1
   skip: true  # [py<39]
 
 requirements:
@@ -40,6 +40,8 @@ requirements:
     - scipy >=1.8  # [aarch64]
     - joblib >=1.2.0
     - threadpoolctl >=3.1.0
+    - llvm-openmp  # [osx]
+    - libgomp  # [linux]
   run:
     - python
     - scipy


### PR DESCRIPTION
This will allow people to use `scikit-learn` with `llvm-openmp` versions as old as the compiler. This is useful in other conda-builds where `llvm-openmp` is pinned to the clang version.

I did rerender locally, but no changes were produced.