### PR TITLE
MAINT Remove PyPy

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,6 +12,7 @@ source:
 build:
   number: 1
   skip: true  # [py<39]
+  skip: true  # [python_impl == "pypy"]
 
 requirements:
   build:


### PR DESCRIPTION
PyPy official support has been dropped: https://github.com/scikit-learn/scikit-learn/pull/29128. This is taken from Scipy as mentioned by @glemaitre in https://github.com/conda-forge/scikit-learn-feedstock/pull/264#discussion_r1625979077.
