### PR TITLE
Add minimum ``scipy`` version constraint

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: 60f3e08038f7395e040254a543948be738c41081c1d3bcf3a56a8116d64fd616
 
 build:
-  number: 0
+  number: 1
   skip: true  # [py<310]
   skip: true  # [python_impl == "pypy"]
 
@@ -45,7 +45,7 @@ requirements:
     - libgomp  # [linux]
   run:
     - python
-    - scipy
+    - scipy >=1.8.0
     - joblib >=1.2.0
     - threadpoolctl >=3.1.0
 


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

Otherwise it's possible to install an incompatible version of `scipy` with `scikit-learn` (which happened over in the Dask test suite) 
