### PR TITLE
MNT Get update bot back

### DIFF
--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -63,6 +63,25 @@ if [[ "${sha:-}" == "" ]]; then
   sha=$(git rev-parse HEAD)
 fi
 
+if [[ "${OSX_SDK_DIR:-}" == "" ]]; then
+  if [[ "${CI:-}" == "" ]]; then
+    echo "Please set OSX_SDK_DIR to a directory where SDKs can be downloaded to. Aborting"
+    exit 1
+  else
+    export OSX_SDK_DIR=/opt/conda-sdks
+    /usr/bin/sudo mkdir -p "${OSX_SDK_DIR}"
+    /usr/bin/sudo chown "${USER}" "${OSX_SDK_DIR}"
+  fi
+else
+  if tmpf=$(mktemp -p "$OSX_SDK_DIR" tmp.XXXXXXXX 2>/dev/null); then
+      rm -f "$tmpf"
+      echo "OSX_SDK_DIR is writeable without sudo, continuing"
+  else
+      echo "User-provided OSX_SDK_DIR is not writeable for current user! Aborting"
+      exit 1
+  fi
+fi
+
 echo -e "\n\nRunning the build setup script."
 source run_conda_forge_build_setup
 

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -3,7 +3,7 @@ schema_version: 1
 context:
   full_version: "1.8.0"
   # X.Y.Z-N used in rare cases for PyPI releases
-  version: ${{ full_version.split("-")[0] }}
+  version: ${{ (full_version | split("-"))[0] }}
 
 package:
   name: scikit-learn

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -1,13 +1,13 @@
 schema_version: 1
 
 context:
-  full_version: "1.8.0"
+  version: "1.8.0"
   # X.Y.Z-N used in rare cases for PyPI releases
-  version: ${{ (full_version | split("-"))[0] }}
+  version_sanitized: ${{ (version | split("-"))[0] }}
 
 package:
   name: scikit-learn
-  version: ${{ version }}
+  version: ${{ version_sanitized }}
 
 source:
   url: https://github.com/scikit-learn/scikit-learn/archive/${{ version }}.tar.gz

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -2,17 +2,14 @@ schema_version: 1
 
 context:
   version: "1.8.0"
-  # sometimes used to match PyPI releases
-  # NOTE: rattler-build does not support empty strings, therefore we use
-  # whitespace that we trim to get an empty string
-  tag: " "
 
 package:
   name: scikit-learn
-  version: ${{ version }}
+  # X.Y.Z-N used in rare cases for PyPI releases
+  version: ${{ version.split("-")[0] }}
 
 source:
-  url: https://github.com/scikit-learn/scikit-learn/archive/${{ version }}${{ tag | trim }}.tar.gz
+  url: https://github.com/scikit-learn/scikit-learn/archive/${{ version }}.tar.gz
   sha256: 603bff01ab8bd0a9de5a3ab0a9351b5d7f5594594cc070d763c537ecf397264f
 
 build:

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -1,12 +1,13 @@
 schema_version: 1
 
 context:
-  version: "1.8.0"
+  full_version: "1.8.0"
+  # X.Y.Z-N used in rare cases for PyPI releases
+  version: ${{ full_version.split("-")[0] }}
 
 package:
   name: scikit-learn
-  # X.Y.Z-N used in rare cases for PyPI releases
-  version: ${{ version.split("-")[0] }}
+  version: ${{ version }}
 
 source:
   url: https://github.com/scikit-learn/scikit-learn/archive/${{ version }}.tar.gz


### PR DESCRIPTION
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [X] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.

Apparently one reason why we don't get the bot automated PRs is because the url needs follow a specific pattern and `{{ tag }}` breaks that see https://github.com/conda-forge/cython-feedstock/pull/185#issuecomment-3686196627.

To be honest I don't think we are planning to use `X.Y.Z-N` kind of release on PyPI any time soon. IIRC this was used only for 1.4 because we messed up something but that was quite painful and we may never do it again and go for a `X.Y.1` in a similar situation in the future. Maybe @ogrisel remembers more?

If we are not planning to use this tag again, maybe we can remove it from the conda-forge recipe?

Something which is not clear to me: is it a good idea to keep the build number fixed and merge this PR anyway? This feels like a maintenance fix and I don't really want new packages to be uploaded with a new build number, but maybe that's a bad idea to keep the build number constant?